### PR TITLE
clarify how to configure resque-clues in a stand alone application

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,12 @@ end
 ```
 
 If used in a Rails application, this will need to be executed in an initalizer.
-After this, you should see events publishe as appropriate for your configured
-event publisher.
+If used outside of a Rails application, this will need to be executed in the Rakefile
+to ensure that both the application enqueuing jobs and the workers are configured. 
+This can be done by creating an initializer and requiring it in your Rakefile 
+after you have required both resque and resque-clues. After this, you should see 
+events published as appropriate for your configured event publisher.
+
 
 ## Contributing
 


### PR DESCRIPTION
Here is a small pull request to make it clear in the documentation that the clues configuration should be done in the Rakefile for stand alone applications of resque-clues.
