### PR TITLE
Correctly specify exception name

### DIFF
--- a/lib/resque/plugins/clues/job_extension.rb
+++ b/lib/resque/plugins/clues/job_extension.rb
@@ -51,7 +51,7 @@ module Resque
               metadata = payload['clues_metadata']
               if Clues.configured? and metadata
                 metadata['time_to_perform'] = Clues.time_delta_since(@perform_started)
-                metadata['exception'] = exception.class
+                metadata['exception'] = exception.class.name
                 metadata['message'] = exception.message
                 metadata['backtrace'] = exception.backtrace
                 Clues.event_publisher.publish(:failed, Clues.now, queue, metadata, payload['class'], *payload['args'])

--- a/spec/job_extension_spec.rb
+++ b/spec/job_extension_spec.rb
@@ -73,7 +73,7 @@ describe Resque::Plugins::Clues::JobExtension do
         it "should include the exception class" do
           @job.fail(Exception.new)
           verify_event :failed do |metadata|
-            metadata['exception'].should == Exception
+            metadata['exception'].should == 'Exception'
           end
         end
 


### PR DESCRIPTION
We were incorrectly assuming that the exception class would be correctly coerced into a string when marshalling the event data, but this was not the case.  It would show up in JSON as an empty object {}.  This will correctly store the exception class name instead.
