### PR TITLE
Allow access to clues_metadata during jobs perform method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 language: ruby
 rvm:
 - 1.9.3
+- 2.0.0
+- 2.1.1
+- 2.1.2
 services:
 - redis-server
 notifications:

--- a/README.md
+++ b/README.md
@@ -87,9 +87,12 @@ happened to any job entering your background queues.
 ## Surfacing Other Data
 
 The above works to surface backgrounding data as described in the lifecycle events
-section.  But you may want to break down your data along other axis.  To accomplish 
-this, you need to use an item preprocessor, which is just a block invoked before
-enqueing the job to further decorate the item stored in redis:
+section.  But you may want to break down your data along other axis.  There are
+two mechanisms to accomplish this -- **item preprocessors** and **runtime access
+to the clues metadata***.
+
+An item preprocessor is a block invoked before enqueing the job to further
+decorate the item stored in redis:
 
 ```ruby
 Resque::Plugins::Clues.item_preprocessor = proc do |queue, item| 
@@ -106,11 +109,33 @@ The item is a hash using string keys.  Its structure is as follows:
   'clues_metadata' => {}
 }
 ```
+Thus you can inject additional data that you want included with all events into
+the item's ```clues_metadata``` hash.  This wiring needs to be executed prior
+to any jobs being enqueued or dequeued within the application code, such as
+in a Rails initializer.
 
-Whatever additional data you want to track should be injected into the item's 
-```clues_metadata``` hash, and will be included in all other downstream events
-for a job.  This wiring codealso needs to be executed prior to any jobs being
-enqueued or dequeuend within the application code, such as a Rails initializer.
+Access to the clues metadata during a job's runtime is provided with the
+```Resque::Plugins::Clues::Runtime``` mixin.  It defines a ```#clues_metadata```
+method that will return the clues_metadata hash that can be injected with
+arbitrary data.  That data will be included with the perform_finished or failed
+events when the job completes.  Here is an example of one way you might use it:
+
+```ruby
+class PdfGenerationJob
+  extend Resque::Plugins::Clues::Runtime
+
+  @queue = pdf_generation
+  def self.perform(doc_id)
+    doc = Document.find(doc_id)
+    clues_metadata[:pdf_generation_strategy] = doc.strategy
+    doc.strategy.constantize.new(doc).generate!
+  end
+end
+```
+
+With your visualization tool, you could then break down performance graphs
+of these jobs by ```pdf_generation_strategy``` to have more fine grained
+performance metrics.
 
 ## Event Format
 By default, resque clues publishes events in a JSON format using an event marshaller.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ end
 
 With your visualization tool, you could then break down performance graphs
 of these jobs by ```pdf_generation_strategy``` to have more fine grained
-performance metrics.
+performance metrics.  Note, Clues metadata that is system-generated will
+have a name that is prefixed with '_'.  Data injected into one of these
+system metadata fields during a perform method will be ignored.
 
 ## Event Format
 By default, resque clues publishes events in a JSON format using an event marshaller.
@@ -156,9 +158,9 @@ Here is n example of a resque clues event as marshalled to JSON:
   "timestamp":"2013-06-04T20:59:58Z",
   "queue":"test_queue",
   "metadata": {
-    "event_hash":"0695f49c5e70fc18da91961113e1769a"
-    "hostname":"Lances-MacBook-Air.local",
-    "process":30731
+    "_event_hash":"0695f49c5e70fc18da91961113e1769a"
+    "_hostname":"Lances-MacBook-Air.local",
+    "_process":30731
   },
   "worker_class":"TestWorker",
   "args":[1,2]

--- a/lib/resque-clues.rb
+++ b/lib/resque-clues.rb
@@ -3,6 +3,7 @@ require 'resque/plugins/clues/util'
 require 'resque/plugins/clues/queue_extension'
 require 'resque/plugins/clues/job_extension'
 require 'resque/plugins/clues/event_publisher'
+require 'resque/plugins/clues/runtime'
 require 'resque/plugins/clues/version'
 
 module Resque

--- a/lib/resque/plugins/clues/job_extension.rb
+++ b/lib/resque/plugins/clues/job_extension.rb
@@ -31,7 +31,9 @@ module Resque
               @perform_started = Time.now
               Clues::Runtime.clues_metadata = payload['clues_metadata']
               _base_perform.tap do
-                payload['clues_metadata']['time_to_perform'] = Clues.time_delta_since(@perform_started)
+                payload['clues_metadata']['_time_to_perform'] =
+                  payload['clues_metadata']['time_to_perform'] =
+                    Clues.time_delta_since(@perform_started)
                 Clues::Runtime.merge!(payload['clues_metadata'])
                 Clues.event_publisher.publish(:perform_finished, Clues.now, queue, payload['clues_metadata'], payload['class'], *payload['args'])
               end
@@ -52,10 +54,18 @@ module Resque
             _base_fail(exception).tap do
               metadata = payload['clues_metadata']
               if Clues.configured? and metadata
-                metadata['time_to_perform'] = Clues.time_delta_since(@perform_started)
-                metadata['exception'] = exception.class.name
-                metadata['message'] = exception.message
-                metadata['backtrace'] = exception.backtrace
+                metadata['_time_to_perform'] =
+                  metadata['time_to_perform'] =
+                    Clues.time_delta_since(@perform_started)
+                metadata['_exception'] =
+                  metadata['exception'] =
+                    exception.class.name
+                metadata['_message'] =
+                  metadata['message'] =
+                    exception.message
+                metadata['_backtrace'] =
+                  metadata['backtrace'] =
+                    exception.backtrace
                 Clues::Runtime.merge!(metadata)
                 Clues.event_publisher.publish(:failed, Clues.now, queue, metadata, payload['class'], *payload['args'])
               end

--- a/lib/resque/plugins/clues/queue_extension.rb
+++ b/lib/resque/plugins/clues/queue_extension.rb
@@ -33,6 +33,10 @@ module Resque
         def _clues_push(queue, item)
           return _base_push(queue, item) unless Clues.clues_configured?
           item['clues_metadata'] = {
+            '_event_hash' => Clues.event_hash,
+            '_hostname' => Clues.hostname,
+            '_process' => Clues.process,
+            '_enqueued_time' => Time.now.utc.to_f,
             'event_hash' => Clues.event_hash,
             'hostname' => Clues.hostname,
             'process' => Clues.process,
@@ -55,9 +59,15 @@ module Resque
             # TODO refactor
             unless item.nil?
               if Clues.clues_configured? and item['clues_metadata']
-                item['clues_metadata']['hostname'] = Clues.hostname
-                item['clues_metadata']['process'] = Clues.process
-                item['clues_metadata']['time_in_queue'] = Clues.time_delta_since(item['clues_metadata']['enqueued_time'])
+                item['clues_metadata']['_hostname'] =
+                  item['clues_metadata']['hostname'] =
+                    Clues.hostname
+                item['clues_metadata']['_process'] =
+                  item['clues_metadata']['process'] =
+                    Clues.process
+                item['clues_metadata']['_time_in_queue'] =
+                  item['clues_metadata']['time_in_queue'] =
+                    Clues.time_delta_since(item['clues_metadata']['_enqueued_time'])
                 Clues.event_publisher.publish(:dequeued, Clues.now, queue, item['clues_metadata'], item['class'], *item['args'])
               end
             end

--- a/lib/resque/plugins/clues/runtime.rb
+++ b/lib/resque/plugins/clues/runtime.rb
@@ -1,0 +1,72 @@
+module Resque
+  module Plugins
+    module Clues
+      ##
+      # The Resque-Clues runtime environment.  Allows
+      # jobs to access the clues metadata, add data to
+      # it that will be broadcast with clues events,
+      # etc...
+      module Runtime
+        class ContextNotEstablished < StandardError; end
+
+        class << self
+          ##
+          # Access to the current thread's clues metadata
+          # hash.
+          def clues_metadata
+            get_thread_local(:clues_metadata) || {}
+          end
+
+          ##
+          # Specify the current thread's clues metadata
+          # hash.
+          def clues_metadata=(hash)
+            set_thread_local(:clues_metadata, hash.dup)
+          end
+
+          ##
+          # Clear the current clues runtime context
+          def clear!
+            delete_thread_local! :clues_metadata
+          end
+
+          ##
+          # Merge any new data stored in the copy of the clues
+          # metadata into an original clues_metadata hash,
+          # ignoring anything that would overwrite existing
+          # metadata and converting keys to strings.
+          def merge!(original)
+            clues_metadata.keys.each do |key|
+              unless original.has_key?(key.to_s)
+                original[key.to_s] = clues_metadata[key]
+              end
+            end
+          end
+
+          private
+          def set_thread_local(name, val)
+            Thread.current[name] = val
+          end
+
+          def get_thread_local(name)
+            Thread.current[name]
+          end
+
+          def delete_thread_local!(name)
+            Thread.current[name] = nil
+          end
+        end
+
+        ##
+        # Convenient access to the clues metadata hash
+        # via mixin. Can be used from within a job's
+        # perform method to store arbitrary data that
+        # will be published with the resque clues
+        # events.
+        def clues_metadata
+          Clues::Runtime.clues_metadata
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/clues/version.rb
+++ b/lib/resque/plugins/clues/version.rb
@@ -1,5 +1,5 @@
 module Resque
   module Clues
-    VERSION = "0.1.1"
+    VERSION = '1.0.0-alpha'
   end
 end

--- a/resque-clues.gemspec
+++ b/resque-clues.gemspec
@@ -21,7 +21,11 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'multi_json', '~> 1.7.4'
   gem.add_development_dependency 'rake', '~> 0.9.2.2'
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'pry'
-  gem.add_development_dependency 'pry-debugger'
   gem.add_development_dependency 'cane'
+  gem.add_development_dependency 'pry'
+  if RUBY_VERSION.split('.').first.to_i >= 2
+    gem.add_development_dependency 'pry-byebug'
+  else
+    gem.add_development_dependency 'pry-debugger'
+  end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -52,9 +52,7 @@ describe 'end-to-end integration' do
   end
 
   def work
-    timeout(0.2) do
-      @worker.work(0.1)
-    end
+    timeout(0.2){ @worker.work(0.1) } rescue nil
   end
 
   def work_and_verify(&block)

--- a/spec/job_extension_spec.rb
+++ b/spec/job_extension_spec.rb
@@ -49,6 +49,7 @@ describe Resque::Plugins::Clues::JobExtension do
       it "should publish a perform_finished event that includes the time_to_perform" do
         job.perform
         verify_event :perform_finished do |metadata|
+          expect(metadata['_time_to_perform']).to_not be_nil
           expect(metadata['time_to_perform']).to_not be_nil
         end
       end
@@ -94,6 +95,7 @@ describe Resque::Plugins::Clues::JobExtension do
         it "should include the time_to_perform" do
           job.fail(Exception.new)
           verify_event :failed do |metadata|
+            expect(metadata['_time_to_perform']).to_not be_nil
             expect(metadata['time_to_perform']).to_not be_nil
           end
         end
@@ -101,6 +103,7 @@ describe Resque::Plugins::Clues::JobExtension do
         it "should include the exception class" do
           job.fail(Exception.new)
           verify_event :failed do |metadata|
+            expect(metadata['_exception']).to eq('Exception')
             expect(metadata['exception']).to eq('Exception')
           end
         end
@@ -108,6 +111,7 @@ describe Resque::Plugins::Clues::JobExtension do
         it "should include the exception message" do
           job.fail(Exception.new('test'))
           verify_event :failed do |metadata|
+            expect(metadata['_message']).to eq("test")
             expect(metadata['message']).to eq("test")
           end
         end
@@ -118,6 +122,7 @@ describe Resque::Plugins::Clues::JobExtension do
           rescue => e
             job.fail(e)
             verify_event :failed do |metadata|
+              expect(metadata['_backtrace']).to_not be_nil
               expect(metadata['backtrace']).to_not be_nil
             end
           end

--- a/spec/job_extension_spec.rb
+++ b/spec/job_extension_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 
 describe Resque::Plugins::Clues::JobExtension do
-  def base_item(overrides={})
-    {"class" => TestWorker.to_s, "args" => [1,2]}.merge!(overrides)
-  end
-
   before do
     Resque::Plugins::Clues.event_publisher = nil
-    @job = Resque::Job.new(:test_queue, base_item('clues_metadata' => {}))
   end
+  let(:base_item) do
+    {
+      "class" => TestWorker.to_s,
+      "args" => [1,2],
+      "clues_metadata" => {}
+    }
+  end
+  let(:job) { Resque::Job.new(:test_queue, base_item) }
 
   it "should pass Resque lint detection" do
     Resque::Plugin.lint(Resque::Plugins::Clues::JobExtension)
@@ -17,15 +20,15 @@ describe Resque::Plugins::Clues::JobExtension do
   context "with clues not configured" do
     describe "#perform" do
       it "should delegate to original perform" do
-        @job.should_receive(:_base_perform)
-        @job.perform
+        job.should_receive(:_base_perform)
+        job.perform
       end
     end
 
     describe "#fail" do
       it "should delegate to original fail" do
-        @job.should_receive(:_base_fail)
-        @job.fail(Exception.new)
+        job.should_receive(:_base_fail)
+        job.fail(Exception.new)
       end
     end
   end
@@ -39,48 +42,73 @@ describe Resque::Plugins::Clues::JobExtension do
 
     describe "#perform" do
       it "should publish a perform_started event" do
-        @job.perform
+        job.perform
         verify_event :perform_started, event_index: -2
       end
 
       it "should publish a perform_finished event that includes the time_to_perform" do
-        @job.perform
+        job.perform
         verify_event :perform_finished do |metadata|
-          metadata['time_to_perform'].nil?.should == false
+          expect(metadata['time_to_perform']).to_not be_nil
+        end
+      end
+
+      context "when encountering a job that modifies clues metadata at runtime" do
+        let(:base_item) do
+          {
+            "class" => InjectingWorker.to_s,
+            "args" => [{'injection' => true}],
+            "clues_metadata" => {}
+          }
+        end
+
+        it "should publish a perfor_finished event that includes the modified metadta" do
+          job.perform
+          expect(publisher.events.last[:metadata]["injection"]).to eq(true)
         end
       end
     end
 
     describe "#fail" do
       it "should publish a perform_failed event" do
-        @job.fail(Exception.new)
+        job.fail(Exception.new)
         verify_event :failed
       end
 
       it "should delegate to original fail" do
-        @job.should_receive(:_base_fail)
-        @job.fail(Exception.new)
+        job.should_receive(:_base_fail)
+        job.fail(Exception.new)
+      end
+
+      context "when encountering a job that modifies clues metadata at runtime then fails" do
+        before {Resque::Plugins::Clues::Runtime.clues_metadata = {}}
+        let(:clues_metadata) {Resque::Plugins::Clues::Runtime.clues_metadata}
+        it "should publish a perform_finished event that includes the modified metadta" do
+          clues_metadata[:injection] = true
+          job.fail(Exception.new)
+          expect(publisher.events.last[:metadata]["injection"]).to eq(true)
+        end
       end
 
       context "includes metadata in the perform_failed event that should" do
         it "should include the time_to_perform" do
-          @job.fail(Exception.new)
+          job.fail(Exception.new)
           verify_event :failed do |metadata|
-            metadata['time_to_perform'].nil?.should == false
+            expect(metadata['time_to_perform']).to_not be_nil
           end
         end
 
         it "should include the exception class" do
-          @job.fail(Exception.new)
+          job.fail(Exception.new)
           verify_event :failed do |metadata|
-            metadata['exception'].should == 'Exception'
+            expect(metadata['exception']).to eq('Exception')
           end
         end
 
         it "should include the exception message" do
-          @job.fail(Exception.new('test'))
+          job.fail(Exception.new('test'))
           verify_event :failed do |metadata|
-            metadata['message'].should == 'test'
+            expect(metadata['message']).to eq("test")
           end
         end
 
@@ -88,9 +116,9 @@ describe Resque::Plugins::Clues::JobExtension do
           begin
             raise 'test'
           rescue => e
-            @job.fail(e)
+            job.fail(e)
             verify_event :failed do |metadata|
-              metadata['backtrace'].nil?.should == false
+              expect(metadata['backtrace']).to_not be_nil
             end
           end
         end

--- a/spec/queue_extension_spec.rb
+++ b/spec/queue_extension_spec.rb
@@ -54,6 +54,7 @@ describe Resque::Plugins::Clues::QueueExtension do
         it "should contain an event_hash identifying the job entering the queue" do
           Resque.push(:test_queue, base_item)
           verify_event :enqueued do |metadata|
+            metadata['_event_hash'].nil?.should == false
             metadata['event_hash'].nil?.should == false
           end
         end
@@ -61,6 +62,7 @@ describe Resque::Plugins::Clues::QueueExtension do
         it "should contain the host's hostname" do
           Resque.push(:test_queue, base_item)
           verify_event :enqueued do |metadata|
+            metadata['_hostname'].should == `hostname`.strip
             metadata['hostname'].should == `hostname`.strip
           end
         end
@@ -68,6 +70,7 @@ describe Resque::Plugins::Clues::QueueExtension do
         it "should contain the process id" do
           Resque.push(:test_queue, base_item)
           verify_event :enqueued do |metadata|
+            metadata['_process'].should == $$
             metadata['process'].should == $$
           end
         end
@@ -114,6 +117,7 @@ describe Resque::Plugins::Clues::QueueExtension do
         it "should contain the hostname" do
           Resque.pop(:test_queue)
           verify_event :dequeued do |metadata|
+            metadata['_hostname'].should == `hostname`.chop
             metadata['hostname'].should == `hostname`.chop
           end
         end
@@ -121,6 +125,7 @@ describe Resque::Plugins::Clues::QueueExtension do
         it "should contain the process id" do
           Resque.pop(:test_queue)
           verify_event :dequeued do |metadata|
+            metadata['_process'].should == $$
             metadata['process'].should == $$
           end
         end
@@ -128,6 +133,7 @@ describe Resque::Plugins::Clues::QueueExtension do
         it "should contain an enqueued_time" do
           Resque.pop(:test_queue)
           verify_event :dequeued do |metadata|
+            metadata['_time_in_queue'].nil?.should == false
             metadata['time_in_queue'].nil?.should == false
           end
         end

--- a/spec/runtime_spec.rb
+++ b/spec/runtime_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+module Resque
+  module Plugins
+    module Clues
+      describe Runtime do
+        before {Runtime.clear!}
+        let(:clues_metadata) { {'a' => 1} }
+
+        describe "class instance methods" do
+          before { Runtime.clues_metadata = clues_metadata }
+
+          describe "#clues_metadata= and #clues_metadata" do
+            it "should allow setting and getting a clues metadata hash" do
+              expect(Runtime.clues_metadata).to eq(clues_metadata)
+            end
+
+            it "should constrain visibility to the executing thread" do
+              thread = Thread.new {Runtime.clues_metadata = {'b' => 2}}
+              expect(Runtime.clues_metadata).to eq(clues_metadata)
+            end
+
+            it "should dupe the metadata so that its not directly modifiable" do
+              Runtime.clues_metadata['b'] = 2
+              expect(clues_metadata).to eq(clues_metadata)
+            end
+          end
+
+          describe "#merge!" do
+            it "should merge added data back into the original hash" do
+              Runtime.clues_metadata['b'] = 2
+              Runtime.merge!(clues_metadata)
+              expect(clues_metadata).to eq({'a' => 1, 'b' => 2})
+            end
+
+            it "should not overwrite existing values" do
+              Runtime.clues_metadata['a'] = 2
+              Runtime.merge!(clues_metadata)
+              expect(clues_metadata).to eq({'a' => 1})
+            end
+
+            it "should convert symbol keys to strings to preserve payload integrity" do
+              Runtime.clues_metadata[:b] = 2
+              Runtime.merge!(clues_metadata)
+              expect(clues_metadata).to eq({'a' => 1, 'b' => 2})
+            end
+          end
+        end
+
+        describe "mixin methods" do
+          subject {Object.new.extend(Runtime)}
+
+          describe "#clues_metadata" do
+            it "should allow access to the clues metadata once a runtime context is established" do
+              Runtime.clues_metadata = clues_metadata
+              expect(subject.clues_metadata).to eq(clues_metadata)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/test_worker.rb
+++ b/spec/test_worker.rb
@@ -4,3 +4,14 @@ class TestWorker
   def self.perform(first, second)
   end
 end
+
+class InjectingWorker
+  extend Resque::Plugins::Clues::Runtime
+  @queue = :test_queue
+
+  def self.perform(hash)
+    hash.each do |k, v|
+      clues_metadata[k] = v
+    end
+  end
+end


### PR DESCRIPTION
- Added Runtime mixin to provide access to jobs that need it
- Store clues_metadata in a threadlocal dupe
- Merge back data from dupe into original on perform_finish
  or failed
- Updated readme with usage
- cleaned up some specs

Added this to allow us to do things like the following example from the README changes:

``` ruby
class PdfGenerationJob
  extend Resque::Plugins::Clues::Runtime

  @queue = pdf_generation
  def self.perform(doc_id)
    doc = Document.find(id)
    clues_metadata[:pdf_generation_strategy] = doc.strategy
    doc.strategy.constantize.new(doc).generate!
  end
end
```

We can then break down our graphs by the strategy used during perform time to see if the job is universally slow or only slow for certain strategies, etc...

Here is a manual verification of this at work.  Define a dummy class like this that injects the clues metadata hash with an environment variable value.

![worker class](http://i.imgur.com/0QMsLJh.png)

Then start two workers with different MESSAGE env variables and make note of their pids.

```
MESSAGE="first worker" QUEUE="test" INTERVAL="0.1" bundle exec rake resque:work &
MESSAGE="second worker" QUEUE="test" INTERVAL="0.1" bundle exec rake resque:work &
```

Open a console and enqueue a few dummy jobs like this:

``` ruby
20.times {Resque.enqueue NoOpWorker}
```

Grep the resque-clues logs for the two env var messages and verify they match the worker pids as expected.

Output for worker 1:

![worker one](http://i.imgur.com/xP3aMb7.png)

Output for worker 2:

![worker two](http://i.imgur.com/FkMItoS.png)
